### PR TITLE
fix: parameter issues for deleteNamespacedSecret

### DIFF
--- a/packages/probot-kubernetes/index.ts
+++ b/packages/probot-kubernetes/index.ts
@@ -22,7 +22,8 @@ const k8sNamespace = (() => {
       'utf8'
     );
   } else {
-    return k8sContext.split('/')[0];
+    const ctx = kc.getContextObject(k8sContext);
+    return ctx?.namespace || 'default';
   }
 })();
 
@@ -59,9 +60,11 @@ const createSecretPayload = async (context: any) => {
   const appAuth = (await context.octokit.auth({
     type: 'installation',
   })) as InstallationAccessTokenAuthentication;
+
+  // orgName may not exist in payload
   const orgName =
     context.payload.installation?.account?.login ||
-    context.payload.organization.login;
+    context.payload.organization?.login;
 
   return {
     metadata: {

--- a/packages/probot-kubernetes/index.ts
+++ b/packages/probot-kubernetes/index.ts
@@ -89,8 +89,8 @@ export const createTokenSecret = async (context: any) => {
 export const deleteTokenSecret = async (context: any) => {
   return useApi(k8s.CoreV1Api)
     .deleteNamespacedSecret(
-      getNamespace(),
-      SECRET_NAME_PREFIX + context.payload.installation.id
+      SECRET_NAME_PREFIX + context.payload.installation.id,
+      getNamespace()
     )
     .catch(unpackExceptionMessage);
 };


### PR DESCRIPTION
Swaps parameters for the deleteNamespacedSecret function. Parameters were previously passed backwards (namespace, secret name) which was causing the function to fail and crash the application when executed. Parameters are now passed correctly (secret name, namespace) to rectify this issue. 